### PR TITLE
better decoupling

### DIFF
--- a/hadoop-unit-pulsar-biscuit/src/main/java/com/clevercloud/hadoopunit/pulsar/PulsarConfig.java
+++ b/hadoop-unit-pulsar-biscuit/src/main/java/com/clevercloud/hadoopunit/pulsar/PulsarConfig.java
@@ -25,11 +25,11 @@ public class PulsarConfig {
 
     public static final String PULSAR_IP_CLIENT_KEY = "pulsar.client.ip";
 
-    public static final String PULSAR_AUTHENTICATION_ENABLED = "true";
-    public static final String PULSAR_AUTHENTICATION_PROVIDERS = "com.clevercloud.biscuitpulsar.BiscuitAuthenticationPlugin";
-    public static final String PULSAR_AUTHORIZATION_ENABLED = "true";
-    public static final String PULSAR_AUTHORIZATION_PROVIDER = "com.clevercloud.biscuitpulsar.BiscuitAuthorizationPlugin";
-    public static final String PULSAR_BISCUIT_ROOT_KEY = "da905388864659eb785877a319fbc42c48e2f8a40af0c5baea0ef8ff7c795253";
+    public static final String PULSAR_AUTHENTICATION_ENABLED_KEY = "pulsar.authentication.enabled";
+    public static final String PULSAR_AUTHENTICATION_PROVIDERS_KEY = "pulsar.authentication.provider";
+    public static final String PULSAR_AUTHORIZATION_ENABLED_KEY = "pulsar.authorization.enabled";
+    public static final String PULSAR_AUTHORIZATION_PROVIDER_KEY = "pulsar.authorisztion.provider";
+    public static final String PULSAR_EXTRA_CONF_KEY = "pulsar.extra.conf";
 
     private PulsarConfig() {}
 }

--- a/hadoop-unit-pulsar-biscuit/src/main/resources/hadoop-unit-default.properties
+++ b/hadoop-unit-pulsar-biscuit/src/main/resources/hadoop-unit-default.properties
@@ -16,6 +16,12 @@ pulsar.port=22022
 pulsar.http.port=22023
 pulsar.temp.dir=/pulsar
 pulsar.streamer.storage.port=4181
+pulsar.authentication.enabled=true
+pulsar.authentication.provider=com.clevercloud.biscuitpulsar.BiscuitAuthenticationPlugin
+pulsar.authorization.enabled=true
+pulsar.authorisztion.provider=com.clevercloud.biscuitpulsar.BiscuitAuthorizationPlugin
+pulsar.extra.conf=biscuitRootKey=da905388864659eb785877a319fbc42c48e2f8a40af0c5baea0ef8ff7c795253
+
 
 pulsar.client.ip=127.0.0.1
 

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -166,6 +166,13 @@
               <groupId>com.clevercloud</groupId>
               <version>1.0-SNAPSHOT</version>
               <mainClass>com.clevercloud.hadoopunit.pulsar.PulsarBootstrap</mainClass>
+              <properties>
+                <pulsar.authentication.enabled>true</pulsar.authentication.enabled>
+                <pulsar.authentication.provider>com.clevercloud.biscuitpulsar.BiscuitAuthenticationPlugin</pulsar.authentication.provider>
+                <pulsar.authorization.enabled>true</pulsar.authorization.enabled>
+                <pulsar.authorisztion.provider>com.clevercloud.biscuitpulsar.BiscuitAuthorizationPlugin</pulsar.authorisztion.provider>
+                <pulsar.extra.conf>biscuitRootKey=da905388864659eb785877a319fbc42c48e2f8a40af0c5baea0ef8ff7c795253</pulsar.extra.conf>
+              </properties>
             </componentArtifact>
           </components>
         </configuration>


### PR DESCRIPTION
but seems to break things with functions... :(

```bash
01:27:27.395 [hadoop-unit-runner] ERROR org.apache.pulsar.functions.worker.SchedulerManager - Exception while at creating producer to topic persistent://public/functions/assignments
java.util.concurrent.ExecutionException: org.apache.pulsar.client.api.PulsarClientException: Connection already closed
	at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:357) ~[?:1.8.0_211]
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1915) ~[?:1.8.0_211]
	at org.apache.pulsar.functions.worker.SchedulerManager.lambda$createProducer$0(SchedulerManager.java:109) ~[pulsar-functions-worker-2.4.1.jar:2.4.1]
	at org.apache.pulsar.functions.utils.Actions.runAction(Actions.java:110) ~[pulsar-functions-utils-2.4.1.jar:2.4.1]
	at org.apache.pulsar.functions.utils.Actions.run(Actions.java:92) ~[pulsar-functions-utils-2.4.1.jar:2.4.1]
	at org.apache.pulsar.functions.worker.SchedulerManager.createProducer(SchedulerManager.java:125) ~[pulsar-functions-worker-2.4.1.jar:2.4.1]
	at org.apache.pulsar.functions.worker.SchedulerManager.<init>(SchedulerManager.java:91) ~[pulsar-functions-worker-2.4.1.jar:2.4.1]
	at org.apache.pulsar.functions.worker.WorkerService.start(WorkerService.java:152) ~[pulsar-functions-worker-2.4.1.jar:2.4.1]
	at org.apache.pulsar.broker.PulsarService.startWorkerService(PulsarService.java:1046) ~[pulsar-broker-2.4.1.jar:2.4.1]
	at org.apache.pulsar.broker.PulsarService.start(PulsarService.java:459) ~[pulsar-broker-2.4.1.jar:2.4.1]
	at com.clevercloud.hadoopunit.pulsar.PulsarBootstrap.start(PulsarBootstrap.java:255) ~[hadoop-unit-pulsar-biscuit-1.0-SNAPSHOT.jar:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_211]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_211]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_211]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_211]
	at fr.jetoile.hadoopunit.HadoopUnitRunnable.loadAndRun(HadoopUnitRunnable.java:269) ~[?:?]
	at fr.jetoile.hadoopunit.HadoopUnitRunnable.lambda$run$2(HadoopUnitRunnable.java:123) ~[?:?]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382) [?:1.8.0_211]
	at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:580) [?:1.8.0_211]
	at fr.jetoile.hadoopunit.HadoopUnitRunnable.run(HadoopUnitRunnable.java:98) [hadoop-unit-maven-plugin-3.6.jar:?]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_211]
Caused by: org.apache.pulsar.client.api.PulsarClientException: Connection already closed
	at org.apache.pulsar.client.impl.ClientCnx.channelInactive(ClientCnx.java:221) ~[pulsar-client-original-2.4.1.jar:2.4.1]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelInputClosed(ByteToMessageDecoder.java:390) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelInactive(ByteToMessageDecoder.java:355) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelInactive(DefaultChannelPipeline.java:1429) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelInactive(DefaultChannelPipeline.java:947) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe$8.run(AbstractChannel.java:826) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:335) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:909) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-all-4.1.32.Final.jar:4.1.32.Final]
	... 1 more
```