### PR TITLE
chore(publish): update workflow and pom to use new Sonatype Central

### DIFF
--- a/.github/workflows/deploy_to_central.yml
+++ b/.github/workflows/deploy_to_central.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Install gpg secret key
         run: |
-          cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
+          cat <(echo -e "${{ secrets.CENTRAL_GPG_SECRET_KEY }}") | gpg --batch --import
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
@@ -20,11 +20,11 @@ jobs:
         with:
           java-version: "21"
           distribution: "temurin"
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Publish package
-        run: mvn --batch-mode -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} deploy -Pdeploy
+        run: mvn --batch-mode -Dgpg.passphrase=${{ secrets.CENTRAL_GPG_SECRET_KEY_PASSWORD }} deploy -Pdeploy
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.class
 target/
 .idea/
+.env*
 
 # Log file
 *.log

--- a/pom.xml
+++ b/pom.xml
@@ -126,14 +126,13 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>${nexus-staging-maven.version}</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
         <extensions>true</extensions>
         <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Since OSSRH is sunsetting next month, this configures the new publish path